### PR TITLE
makes the view writable from a compute shader in ipadOS

### DIFF
--- a/ch18/chapter18.playground/Sources/MetalView.swift
+++ b/ch18/chapter18.playground/Sources/MetalView.swift
@@ -19,6 +19,7 @@ public class MetalView: NSObject, MTKViewDelegate {
         
         super.init()
         view.delegate = self
+        view.framebufferOnly = false
         view.device = device
     }
     


### PR DESCRIPTION
fixes #6 and does not affect macOS playground functionality